### PR TITLE
Merge branch 2.0: reflect changes of already published release 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ dist
 *.swp
 .swo
 .DS_Store
+# virtualenv:
+bin/
+include/
+lib/
+lib64

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ bin/
 include/
 lib/
 lib64
+.restore-env.sh
+pyvenv.cfg

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ recursive-include Products *
 recursive-include docs *
 
 global-exclude *pyc
+global-exclude .*.swp
 
 global-include *.mo
 global-include CHANGES.txt

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,17 @@ Development
 
 * Updates to MANIFEST.ini file to ensure package builds properly [pigeonflight]
 
+
+2.0 (2014-11-25)
+~~~~~~~~~~~~~~~~
+
+* Security and performance improvements [matthewwilkes]
+* Remove reimplementation of plone.session [matthewwilkes]
+* Change internal data structures to avoid unnecessary object stores [matthewwilkes]
+* Add tests to test harness [matthewwilkes]
+* Fix pure Zope compatibility [matthewwilkes]
+
+
 1.0b1 (25/11/2014)
 ~~~~~~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def read(filename):
     return open(filename, 'rb').read()
 
 setup(
-    version='1.0b1',
+    version='2.0',
     name='Products.NoDuplicateLogin',
     description='Products.NoDuplicateLogin',
     long_description=read('README.txt') + read('docs/HISTORY.txt'),

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     name='Products.NoDuplicateLogin',
     description='Products.NoDuplicateLogin',
     long_description=read('README.txt') + read('docs/HISTORY.txt'),
+    long_description_content_type='text/x-rst',
     author='Daniel Nouri',
     author_email='daniel.nouri@gmail.com',
     url='http://svn.plone.org/svn/collective/PASPlugins/Products.NoDuplicateLogin',


### PR DESCRIPTION
The current master still specifies version 1.0b1.
I reproduced the changes from the archive;
after taht, we should provide a 2.0.1 bugfix release, containing the MANIFEST.in fix.